### PR TITLE
update: Codespaces using new url

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ if (!port) {
   return;
 }
 
-const id = process.env["CLOUDENV_ENVIRONMENT_ID"];
-const url = `https://${id}-${port}.apps.codespaces.githubusercontent.com`;
+const name = process.env["CODESPACE_NAME"];
+const url = `https://${name}-${port}.githubpreview.dev`;
 
 console.log(url);


### PR DESCRIPTION
Codespaces using a different format. 
domain change: `apps.codespaces.githubusercontent.com` -> `githubpreview.dev`
Environment Variable change (used as subdomain): `CLOUDENV_ENVIRONMENT_ID` -> `CODESPACE_NAME`

I don't know if this is for all Codespace environments, but this is how I had to resolve my Codespace url. 

Thanks for you package btw, reading it helped me understand how the url was being formed. Prior I was trying all kinds of hacky stuff. 